### PR TITLE
change selector name done: in XLCustomPickerView

### DIFF
--- a/XLiOSKit/ViewController/Helper/XLCustomPickerView.h
+++ b/XLiOSKit/ViewController/Helper/XLCustomPickerView.h
@@ -27,7 +27,7 @@
 @protocol XLCustomPickerDelegate <NSObject>
 
 @required
-- (void)done:(NSInteger)selectedRow;
+- (void)doneWithSelectedRow:(NSInteger)row;
 - (void)cancel;
 
 @end

--- a/XLiOSKit/ViewController/Helper/XLCustomPickerView.m
+++ b/XLiOSKit/ViewController/Helper/XLCustomPickerView.m
@@ -163,7 +163,7 @@
 - (void)doneButtonDidTouch:(id)sender
 {
     [self dismissActionSheet:YES];
-    [self.delegate done:_selectedRow];
+    [self.delegate doneWithSelectedRow:_selectedRow];
 }
 
 - (void)cancelButtonDidTouch:(id)sender


### PR DESCRIPTION
change selector name due to "iTunes Store operation failed. The app reference non-public selectors in Payload done: " when trying to make a build for app store 
