### PR TITLE
Fix font for iOS9 compatibility

### DIFF
--- a/XLiOSKit/View/ProgressView/XLTitledAndCancellableProgressView.m
+++ b/XLiOSKit/View/ProgressView/XLTitledAndCancellableProgressView.m
@@ -120,7 +120,7 @@
     if (_titleLabel) return _titleLabel;
     _titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, TOP_BOTTOM_MARGIN + 3, 100, 20)];
     _titleLabel.layer.zPosition = 1;
-    _titleLabel.font = [UIFont fontWithName:@"HelveticaNeue-Bold" size:10.0f];
+    _titleLabel.font = [UIFont boldSystemFontOfSize:10.0f];
     
     [_titleLabel setBackgroundColor:[UIColor redColor]];
     

--- a/XLiOSKit/View/XLCustomSheetView.m
+++ b/XLiOSKit/View/XLCustomSheetView.m
@@ -144,7 +144,7 @@
     _titleLabel = [[UILabel alloc] initWithFrame:CGRectZero];
     _titleLabel.backgroundColor = kCancelButtonBackground;
     _titleLabel.textColor = kTitleFontColor;
-    _titleLabel.font = [UIFont fontWithName:@"HelveticaNeue-Bold" size:18.0];
+    _titleLabel.font = [UIFont boldSystemFontOfSize:18.0f];
     _titleLabel.textAlignment = NSTextAlignmentCenter;
     return _titleLabel;
 }


### PR DESCRIPTION
On iOS9 the use of HelveticaNeue produces strange effects in the TextRendering like some places showing in AllCaps

Usage of `systemFont` allows the OS to choose the appropriate version according to the iOS running.

cc: @HelOlhausen 