### PR TITLE
Fix crash when method's parameter are nil

### DIFF
--- a/XLiOSKit/Category/NSManagedObject+Additions.m
+++ b/XLiOSKit/Category/NSManagedObject+Additions.m
@@ -91,8 +91,11 @@
 
 +(instancetype)objectWithID:(NSManagedObjectID *)managedObjectID inContext:(NSManagedObjectContext *)context
 {
-    NSError *error;
-    return [context existingObjectWithID:managedObjectID error:&error];
+    if (!managedObjectID){
+        return nil;
+    }
+
+    return [context existingObjectWithID:managedObjectID error:nil];
 }
 
 +(NSArray *)allObjectsInContext:(NSManagedObjectContext *)context

--- a/XLiOSKit/Category/NSManagedObject+Additions.m
+++ b/XLiOSKit/Category/NSManagedObject+Additions.m
@@ -29,8 +29,7 @@
 
 +(instancetype)findFirstByAttribute:(NSString *)attribute withValue:(id)value inContext:(NSManagedObjectContext *)context
 {
-    NSString * predicateStr = [NSString stringWithFormat:@"%@ = %%@", attribute];
-    NSPredicate * searchByAttValue = [NSPredicate predicateWithFormat:predicateStr argumentArray:@[value]];
+    NSPredicate * searchByAttValue = [NSPredicate predicateWithFormat:@"%K = %@", attribute, value];
     NSFetchRequest * fetchRequest = [self fetchRequest];
     fetchRequest.predicate = searchByAttValue;
     fetchRequest.fetchLimit = 1;


### PR DESCRIPTION
There are 2 methods in category `NSManagedObject+Additions` that crash the host app when they are called with parameters as nil. They are:

- `findFirstByAttribute:withValue:inContext:` When _value_ parameter is passed as nil, method tries to insert nil into an array.
- `objectWithID:inContext:` When _managedObjectID_ parameter is passed as nil, call to `existingObjectWithID:error:` throws an NSInvalidArgumentException.

I have added some protection around those methods, so they don't crash.