### PR TITLE
Add apostrophe as a valid e-mail character

### DIFF
--- a/XLiOSKit/Category/NSString+XLAdditions.m
+++ b/XLiOSKit/Category/NSString+XLAdditions.m
@@ -30,7 +30,7 @@
 
 -(BOOL)isValidAsEmail:(NSError **)error
 {
-    NSString *regexForEmailAddress = @"[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}";
+    NSString *regexForEmailAddress = @"[A-Z0-9a-z._%+'-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}";
     NSPredicate *emailValidation = [NSPredicate predicateWithFormat:@"SELF MATCHES %@",regexForEmailAddress];
     BOOL success = [emailValidation evaluateWithObject:self];
     if (success == NO && error) {


### PR DESCRIPTION
According to [RFC822](http://www.ietf.org/rfc/rfc0822.txt)'s definition for the local-part, the apostrophe is a valid caracter for the username part of the e-mail address.

Adding it to the `regexForEmailAddress`