### PR TITLE
Comply with Cocoapods 1.0.0

### DIFF
--- a/XLiOSKit.podspec
+++ b/XLiOSKit.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.author       = { 'Martin Barreto' => 'martin@xmartlabs.com', 'Miguel Revetria' => 'miguel@xmartlabs.com' }
 
   s.platform     = :ios
+  s.source   = { :git => 'https://github.com/xmartlabs/XLiOSKit.git', :tag => s.version }
   
   s.subspec 'arc' do |sp|
     sp.source_files = 'XLiOSKit/**/*.{m,h}'


### PR DESCRIPTION
Cocoapods 1.0.0 now requires the explicit value of 

```
s.source 
```
